### PR TITLE
Adds support for IPv6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,8 @@ WORKDIR /go/bin/
 
 COPY . /go/src/github.com/clockworksoul/smudge
 
+RUN go test github.com/clockworksoul/smudge
+
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o smudge github.com/clockworksoul/smudge/smudge
 
 # Part 2: Build the Smudge image proper

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,6 @@ WORKDIR /go/bin/
 
 COPY . /go/src/github.com/clockworksoul/smudge
 
-RUN go test github.com/clockworksoul/smudge
-
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o smudge github.com/clockworksoul/smudge/smudge
 
 # Part 2: Build the Smudge image proper

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Complete documentation is available from [the associated Godoc](https://godoc.or
 
 
 ## Known issues
-* Broadcasts are limited to 256 bytes, or 1280 bytes when using IPv6.
+* Broadcasts are limited to 256 bytes, or 512 bytes when using IPv6.
 * No WAN support: only local-network, private IPs are supported.
 * No multicast discovery.
 
@@ -131,7 +131,7 @@ If you prefer to direct the behavior of the service using the API, the calls are
 smudge.SetListenPort(9999)
 smudge.SetHeartbeatMillis(250)
 smudge.SetListenIP(net.ParseIP("127.0.0.1"))
-smudge.SetMaxBroadcastBytes(256) // set to 1280 when using IPv6
+smudge.SetMaxBroadcastBytes(256) // set to 512 when using IPv6
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,28 @@ To execute the build, you simply need to do the following:
 docker build -t clockworksoul/smudge:latest .
 ```
 
+### Testing the Docker image
+
+You can test Smudge locally using the Docker image. First create a network to use for your Smudge nodes and then add some nodes to the network.
+
+For IPv4 you can use the following commands:
+
+```bash
+docker network create smudge
+docker run -i -t --network smudge --rm clockworksoul/smudge:latest /smudge
+# you can add nodes with the following command
+docker run -i -t --network smudge --rm clockworksould/smudge:latest /smudge -node 172.20.0.2
+```
+
+To try out Smudge with IPv6 you can use the following commands:
+
+```bash
+docker network create --ipv6 --subnet fd02:6b8:b010:9020:1::/80 smudge6
+docker run -i -t --network smudge6 --rm clockworksoul/smudge:latest /smudge
+# you can add nodes with the following command
+docker run -i -t --network smudge6 --rm clockworksould/smudge:latest /smudge -node [fd02:6b8:b010:9020:1::2]:9999
+```
+
 ### Building the binary with the Go compiler
 
 #### Set up your Golang environment

--- a/membership.go
+++ b/membership.go
@@ -447,9 +447,6 @@ func startTimeoutCheckLoop() {
 func transmitVerbGenericUDP(node *Node, forwardTo *Node, verb messageVerb, code uint32) error {
 	// Transmit the ACK
 	remoteAddr, err := net.ResolveUDPAddr("udp", node.Address())
-	if err != nil {
-		return err
-	}
 
 	c, err := net.DialUDP("udp", nil, remoteAddr)
 	if err != nil {

--- a/membership.go
+++ b/membership.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -42,6 +42,8 @@ var thisHostAddress string
 
 var thisHost *Node
 
+var ipLen = net.IPv4len
+
 // This flag is set whenever a known node is added or removed.
 var knownNodesModifiedFlag = false
 
@@ -55,19 +57,15 @@ var pingdata = newPingData(150, 50)
 // Note that this is a blocking function, so act appropriately.
 func Begin() {
 	// Add this host.
-	ip, err := GetLocalIP()
-	if err != nil {
-		logFatal("Could not get local ip:", err)
-		return
-	}
+	logfInfo("Using listen IP: %s\n", listenIP)
 
-	if ip == nil {
-		logWarn("Warning: Could not resolve host IP. Using 127.0.0.1")
-		ip = []byte{127, 0, 0, 1}
+	// Use IPv6 address length if the listen IP is not an IPv4 address
+	if listenIP.To4() == nil {
+		ipLen = net.IPv6len
 	}
 
 	me := Node{
-		ip:         ip,
+		ip:         listenIP,
 		port:       uint16(GetListenPort()),
 		timestamp:  GetNowInMillis(),
 		pingMillis: PingNoData,
@@ -245,7 +243,7 @@ func listenUDP(port int) error {
 	defer c.Close()
 
 	for {
-		buf := make([]byte, 512)
+		buf := make([]byte, 2048) // big enough to fit 1280 IPv6 UDP message
 		n, addr, err := c.ReadFromUDP(buf)
 		if err != nil {
 			logError("UDP read error: ", err)

--- a/message_test.go
+++ b/message_test.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -97,6 +97,7 @@ func TestEncodeDecodeBasic(t *testing.T) {
 
 	ip := net.IP([]byte{127, 0, 0, 1})
 	bytes := message.encode()
+
 	decoded, err := decodeMessage(ip, bytes)
 	decoded.sender.timestamp = timestamp
 
@@ -114,7 +115,46 @@ func TestEncodeDecodeBasic(t *testing.T) {
 	}
 }
 
-// Endode and decode a simple message without one member, and see if
+// Endode and decode a simple IPv6 message without any members, and see if
+// the input/output match.
+func TestEncodeDecodeBasicIPv6(t *testing.T) {
+	timestamp := uint32(87878787)
+
+	sender := Node{
+		ip:         net.IP{255, 254, 253, 252, 251, 250, 240, 230, 220, 210, 200, 10, 20, 30, 40, 50},
+		port:       1234,
+		timestamp:  timestamp,
+		pingMillis: PingNoData,
+	}
+
+	message := message{
+		sender:          &sender,
+		senderHeartbeat: 255,
+		verb:            verbPing}
+
+	ipLen = net.IPv6len // encode IPv6
+	ip := net.IP{255, 254, 253, 252, 251, 250, 240, 230, 220, 210, 200, 10, 20, 30, 40, 50}
+	bytes := message.encode()
+	decoded, err := decodeMessage(ip, bytes)
+	decoded.sender.timestamp = timestamp
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	if !reflect.DeepEqual(message, decoded) {
+		t.Error("Messages do not match:")
+
+		t.Log(" Input:", message)
+		t.Log("Output:", decoded)
+		t.Log(" Input node:", message.sender)
+		t.Log("Output node:", decoded.sender)
+	}
+
+	ipLen = net.IPv4len // reset to IPv4
+}
+
+// Endode and decode a simple message with one member, and see if
 // the input/output match.
 func TestEncodeDecode1Member(t *testing.T) {
 	timestamp := uint32(87878787)
@@ -127,7 +167,7 @@ func TestEncodeDecode1Member(t *testing.T) {
 	}
 
 	member := Node{
-		ip:         net.IP([]byte{127, 0, 0, 2}),
+		ip:         net.IP([]byte{127, 0, 0, 2}).To16(),
 		port:       9000,
 		timestamp:  timestamp,
 		pingMillis: PingNoData,
@@ -145,7 +185,13 @@ func TestEncodeDecode1Member(t *testing.T) {
 
 	ip := net.IP([]byte{127, 0, 0, 1})
 	bytes := message.encode()
+	if len(bytes) != 22 {
+		t.Error("Encoded message length is invalid.")
+		t.Log("Should be 22 but found: ", len(bytes))
+	}
+
 	decoded, err := decodeMessage(ip, bytes)
+	t.Log("bytes: ", bytes)
 	decoded.sender.timestamp = timestamp
 	decoded.members[0].node.timestamp = timestamp
 
@@ -167,7 +213,68 @@ func TestEncodeDecode1Member(t *testing.T) {
 	}
 }
 
-// Endode and decode a simple message without one member, and see if
+// Endode and decode a simple message with one ipv6 member, and see if
+// the input/output match.
+func TestEncodeDecode1MemberIPv6(t *testing.T) {
+	timestamp := uint32(87878787)
+
+	sender := Node{
+		ip:         net.IP{255, 254, 253, 252, 251, 250, 240, 230, 220, 210, 200, 10, 20, 30, 40, 50},
+		port:       1234,
+		timestamp:  timestamp,
+		pingMillis: PingNoData,
+	}
+
+	member := Node{
+		ip:         net.IP{10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150, 160},
+		port:       9000,
+		timestamp:  timestamp,
+		pingMillis: PingNoData,
+	}
+
+	message := message{
+		sender:          &sender,
+		senderHeartbeat: 255,
+		verb:            verbPing}
+	message.addMember(&member, StatusDead, 38)
+
+	if len(message.members) != 1 {
+		t.Error("No member in the input members list!")
+	}
+
+	ipLen = net.IPv6len // encode for IPv6
+	ip := net.IP{255, 254, 253, 252, 251, 250, 240, 230, 220, 210, 200, 10, 20, 30, 40, 50}
+	bytes := message.encode()
+	if len(bytes) != 34 {
+		t.Error("Encoded message length is invalid.")
+		t.Log("Should be 34 but found: ", len(bytes))
+	}
+
+	decoded, err := decodeMessage(ip, bytes)
+	decoded.sender.timestamp = timestamp
+	decoded.members[0].node.timestamp = timestamp
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	if len(decoded.members) != 1 {
+		t.Error("No member in the output members list!")
+	}
+
+	if !reflect.DeepEqual(message, decoded) {
+		t.Error("Messages do not match")
+
+		t.Log(" Input:", message.members[0])
+		t.Log("Output:", decoded.members[0])
+		t.Log(" Input node:", message.members[0].node)
+		t.Log("Output node:", decoded.members[0].node)
+	}
+
+	ipLen = net.IPv4len // reset to IPv4 for next test
+}
+
+// Endode and decode a simple message with one member and message, and see if
 // the input/output match.
 func TestEncodeDecode1MemberBroadcast(t *testing.T) {
 	timestamp := uint32(87878787)
@@ -191,7 +298,7 @@ func TestEncodeDecode1MemberBroadcast(t *testing.T) {
 	message.addMember(&member, StatusDead, 38)
 
 	broadcast := Broadcast{
-		bytes:  []byte("This is a message"),
+		bytes:  []byte("This is a message"), //len=17
 		origin: &sender,
 		index:  42}
 	message.addBroadcast(&broadcast)
@@ -202,6 +309,11 @@ func TestEncodeDecode1MemberBroadcast(t *testing.T) {
 
 	ip := net.IP([]byte{127, 0, 0, 1})
 	bytes := message.encode()
+	if len(bytes) != 51 {
+		t.Error("Encoded message length is invalid.")
+		t.Log("Should be 51 but found: ", len(bytes))
+	}
+
 	decoded, err := decodeMessage(ip, bytes)
 	decoded.sender.timestamp = timestamp
 	decoded.members[0].node.timestamp = timestamp
@@ -222,4 +334,69 @@ func TestEncodeDecode1MemberBroadcast(t *testing.T) {
 		t.Error(" Input bcast:", message.broadcast)
 		t.Error("Output bcast:", decoded.broadcast)
 	}
+}
+
+// Endode and decode a simple message with one ipv6 member and message, and see if
+// the input/output match.
+func TestEncodeDecode1MemberBroadcastIPv6(t *testing.T) {
+	timestamp := uint32(87878787)
+
+	sender := Node{
+		ip:         net.IP{255, 254, 253, 252, 251, 250, 240, 230, 220, 210, 200, 10, 20, 30, 40, 50},
+		port:       1234,
+		timestamp:  timestamp,
+		pingMillis: PingNoData}
+
+	member := Node{
+		ip:         net.IP{10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150, 160},
+		port:       9000,
+		timestamp:  timestamp,
+		pingMillis: PingNoData}
+
+	message := message{
+		sender:          &sender,
+		senderHeartbeat: 255,
+		verb:            verbPing}
+	message.addMember(&member, StatusDead, 38)
+
+	broadcast := Broadcast{
+		bytes:  []byte("This is a message"),
+		origin: &sender,
+		index:  42}
+	message.addBroadcast(&broadcast)
+
+	if message.broadcast == nil {
+		t.Error("Broadcast not set properly")
+	}
+
+	ipLen = net.IPv6len // encode for IPv6
+	ip := net.IP{255, 254, 253, 252, 251, 250, 240, 230, 220, 210, 200, 10, 20, 30, 40, 50}
+	bytes := message.encode()
+	if len(bytes) != 75 {
+		t.Error("Encoded message length is invalid.")
+		t.Log("Should be 75 but found: ", len(bytes))
+	}
+
+	decoded, err := decodeMessage(ip, bytes)
+	decoded.sender.timestamp = timestamp
+	decoded.members[0].node.timestamp = timestamp
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	if decoded.broadcast == nil {
+		t.Error("Broadcast not decoded")
+	}
+
+	message.broadcast.origin = nil
+	decoded.broadcast.origin = nil
+
+	if !reflect.DeepEqual(message.broadcast, decoded.broadcast) {
+		t.Error("Broadcasts do not match:")
+		t.Error(" Input bcast:", message.broadcast)
+		t.Error("Output bcast:", decoded.broadcast)
+	}
+
+	ipLen = net.IPv4len
 }

--- a/node.go
+++ b/node.go
@@ -101,7 +101,10 @@ func (n *Node) Touch() {
 }
 
 func nodeAddressString(ip net.IP, port uint16) string {
-	return fmt.Sprintf("%s:%d", ip, port)
+	if ip.To4() != nil {
+		return fmt.Sprintf("%s:%d", ip.String(), port)
+	}
+	return fmt.Sprintf("[%s]:%d", ip.String(), port)
 }
 
 // GetNowInMillis returns the current local time in milliseconds since the

--- a/properties.go
+++ b/properties.go
@@ -154,6 +154,10 @@ func SetListenPort(val int) {
 // SetListenIP sets the IP to listen on. It has no effect once
 // Begin() has been called.
 func SetListenIP(val net.IP) {
+	if len(AllNodes()) > 0 {
+		logWarn("Do not call SetListenIP() after nodes have been added, it may cause unexpected behavior.")
+	}
+
 	if val == nil {
 		listenIP = net.ParseIP(DefaultListenIP)
 	} else {

--- a/registry.go
+++ b/registry.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -108,9 +108,10 @@ func CreateNodeByIP(ip net.IP, port uint16) (*Node, error) {
 	return &node, nil
 }
 
-// GetLocalIP queries the host interface to determine the local IPv4 of this
-// machine. If a local IPv4 cannot be found, then nil is returned. If the
-// query to the underlying OS fails, an error is returned.
+// GetLocalIP queries the host interface to determine the local IP address of this
+// machine. If a local IP address cannot be found, then nil is returned. Local IPv6
+// address takes presedence over a local IPv4 address. If the query to the underlying
+// OS fails, an error is returned.
 func GetLocalIP() (net.IP, error) {
 	var ip net.IP
 
@@ -123,6 +124,8 @@ func GetLocalIP() (net.IP, error) {
 		if ipnet, ok := a.(*net.IPNet); ok && !ipnet.IP.IsLoopback() {
 			if ipnet.IP.To4() != nil {
 				ip = ipnet.IP.To4()
+			} else {
+				ip = ipnet.IP
 				break
 			}
 		}
@@ -248,17 +251,8 @@ func parseNodeAddress(hostAndMaybePort string) (net.IP, uint16, error) {
 	}
 
 	for _, i := range ips {
-		if i.To4() != nil {
-			ip = i.To4()
-		}
-	}
-
-	if ip.IsLoopback() {
-		ip, err = GetLocalIP()
-
-		if ip == nil {
-			logWarn("Warning: Could not resolve host IP. Using 127.0.0.1")
-			ip = []byte{127, 0, 0, 1}
+		if !i.IsLoopback() {
+			ip = i
 		}
 	}
 

--- a/registry.go
+++ b/registry.go
@@ -251,7 +251,6 @@ func parseNodeAddress(hostAndMaybePort string) (net.IP, uint16, error) {
 	}
 
 	if ip == nil {
-		fmt.Printf("Host = %s\n", host)
 		ips, err := net.LookupIP(host)
 		if err != nil {
 			return ip, port, err

--- a/registry_test.go
+++ b/registry_test.go
@@ -1,0 +1,136 @@
+/*
+Copyright 2016 The Smudge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package smudge
+
+import (
+	"testing"
+)
+
+func TestIPv4(t *testing.T) {
+	s := "127.0.0.1"
+	ip, port, err := parseNodeAddress(s)
+
+	if err != nil {
+		t.Error("Error should be nil but was:", err)
+	}
+
+	if ip.String() != s {
+		t.Errorf("Expected %s but found %s\n", s, ip.String())
+	}
+
+	if port != 9999 {
+		t.Errorf("Expected the port to be 9999 but found %d\n", port)
+	}
+}
+
+func TestIPv4WithPort(t *testing.T) {
+	s := "127.0.0.1:80"
+	ip, port, err := parseNodeAddress(s)
+
+	if err != nil {
+		t.Error("Error should be nil but was:", err)
+	}
+
+	if ip.String() != "127.0.0.1" {
+		t.Errorf("Expected %s but found %s\n", s, ip.String())
+	}
+
+	if port != 80 {
+		t.Errorf("Expected the port to be 80 but found %d\n", port)
+	}
+}
+
+func TestIPv6(t *testing.T) {
+	s := "fd02:6b8:b010:9020:1::2"
+	ip, port, err := parseNodeAddress(s)
+
+	if err != nil {
+		t.Error("Error should be nil but was:", err)
+	}
+
+	if ip.String() != s {
+		t.Errorf("Expected %s but found %s\n", s, ip.String())
+	}
+
+	if port != 9999 {
+		t.Errorf("Expected the port to be 9999 but found %d\n", port)
+	}
+}
+
+func TestIPv6WithPort(t *testing.T) {
+	s := "[fd02:6b8:b010:9020:1::2]:80"
+	ip, port, err := parseNodeAddress(s)
+
+	if err != nil {
+		t.Error("Error should be nil but was:", err)
+	}
+
+	if ip.String() != "fd02:6b8:b010:9020:1::2" {
+		t.Errorf("Expected fd02:6b8:b010:9020:1::2 but found %s\n", ip.String())
+	}
+
+	if port != 80 {
+		t.Errorf("Expected the port to be 80 but found %d\n", port)
+	}
+}
+
+//func TestHostname(t *testing.T) {
+//	s := "localhost"
+//	ip, port, err := parseNodeAddress(s)
+//
+//	if err != nil {
+//		t.Error("Error should be nil but was:", err)
+//	}
+//
+//	if ip.String() != "127.0.0.1" {
+//		t.Errorf("Expected %s but found %s\n", s, ip.String())
+//	}
+//
+//	if port != 9999 {
+//		t.Errorf("Expected the port to be 9999 but found %d\n", port)
+//	}
+//}
+//
+//func TestHostnameWithPort(t *testing.T) {
+//	s := "localhost:80"
+//	ip, port, err := parseNodeAddress(s)
+//
+//	if err != nil {
+//		t.Error("Error should be nil but was:", err)
+//	}
+//
+//	if ip.String() != "127.0.0.1" {
+//		t.Errorf("Expected %s but found %s\n", s, ip.String())
+//	}
+//
+//	if port != 80 {
+//		t.Errorf("Expected the port to be 80 but found %d\n", port)
+//	}
+//}
+//
+//func TestHostnameErr(t *testing.T) {
+//	SetListenIP(net.ParseIP("fd02:6b8:b010:9020:1::2"))
+//
+//	s := "localhost"
+//	_, _, err := parseNodeAddress(s)
+//
+//	if err == nil {
+//		t.Error("Error should not have been be nil")
+//	}
+//
+//	SetListenIP(net.ParseIP("127.0.0.1"))
+//}

--- a/smudge/README.md
+++ b/smudge/README.md
@@ -1,1 +1,1 @@
-This directory is contains a simple CLI tool used to test Smudge's member discovery and status dissemination functionality. 
+This directory is contains a simple CLI tool used to test Smudge's member discovery and status dissemination functionality.

--- a/smudge/smudge.go
+++ b/smudge/smudge.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -46,17 +46,22 @@ func main() {
 		log.Fatal("Could not get local ip:", err)
 	}
 
-	smudge.SetLogThreshold(smudge.LogTrace)
+	smudge.SetLogThreshold(smudge.LogInfo)
 	smudge.SetListenPort(listenPort)
 	smudge.SetHeartbeatMillis(heartbeatMillis)
 	smudge.SetListenIP(ip)
-	//smudge.SetMaxBroadcastBytes(1280) // 1280 for IPv6
+
+	if ip.To4() == nil {
+		smudge.SetMaxBroadcastBytes(1280) // 1280 for IPv6
+	}
 
 	if nodeAddress != "" {
 		node, err := smudge.CreateNodeByAddress(nodeAddress)
 
 		if err == nil {
 			smudge.AddNode(node)
+		} else {
+			fmt.Println(err)
 		}
 	}
 

--- a/smudge/smudge.go
+++ b/smudge/smudge.go
@@ -52,7 +52,7 @@ func main() {
 	smudge.SetListenIP(ip)
 
 	if ip.To4() == nil {
-		smudge.SetMaxBroadcastBytes(1280) // 1280 for IPv6
+		smudge.SetMaxBroadcastBytes(512) // 512 for IPv6
 	}
 
 	if nodeAddress != "" {

--- a/smudge/smudge.go
+++ b/smudge/smudge.go
@@ -20,6 +20,7 @@ import (
 	"flag"
 	"fmt"
 	"github.com/clockworksoul/smudge"
+	"log"
 )
 
 func main() {
@@ -40,9 +41,16 @@ func main() {
 
 	flag.Parse()
 
-	smudge.SetLogThreshold(smudge.LogInfo)
+	ip, err := smudge.GetLocalIP()
+	if err != nil {
+		log.Fatal("Could not get local ip:", err)
+	}
+
+	smudge.SetLogThreshold(smudge.LogTrace)
 	smudge.SetListenPort(listenPort)
 	smudge.SetHeartbeatMillis(heartbeatMillis)
+	smudge.SetListenIP(ip)
+	//smudge.SetMaxBroadcastBytes(1280) // 1280 for IPv6
 
 	if nodeAddress != "" {
 		node, err := smudge.CreateNodeByAddress(nodeAddress)


### PR DESCRIPTION
This is a follow up for #9 which I pushed to soon 👎 

This time it should be fine.

* Adds support for IPv6
* Adds test cases for IPv6
* Removes a duplicate check for origin less broadcast
* Adds a configuration property to set the listen IP address
* The application is now responsible for passing a correct listen IP address to smudge.
* Adds documentation on how to test Smudge with IPv4 and IPv6 using Docker.

This should of course fix issue #7 
