### PR TITLE
Multicast support

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ SMUDGE_LISTEN_IP           |    127.0.0.1    | IP address to listen on
 SMUDGE_MAX_BROADCAST_BYTES |       256       | Maximum byte length of broadcast payloads
 SMUDGE_MULTICAST_ENABLED   |       true      | Multicast announce on startup; listen for multicast announcements
 SMUDGE_MULTICAST_ADDRESS   | See description | The multicast broadcast address. Default: `224.0.0.0` (IPv4) or `[ff02::1]` (IPv6)
+SMUDGE_MULTICAST_PORT      |       9998      | The multicast listen port
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ func main() {
 
 
 ### Adding a new member to the "known nodes" list
-Adding a new member to your known nodes list will also make that node aware of the adding server. Note that because this package doesn't yet support multicast notifications, at this time to join an existing cluster you must use this method to add at least one of that cluster's healthy member nodes.
+Adding a new member to your known nodes list will also make that node aware of the adding server. To join an existing cluster without using multicast (or on a network where multicast is disabled) you must use this method to add at least one of that cluster's healthy member nodes.
 
 ```go
 node, err := smudge.CreateNodeByAddress("localhost:10000")

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Smudge is a minimalist Go implementation of the [SWIM](https://pdfs.semanticscho
 
 Smudge also extends the standard SWIM protocol so that in addition to the standard membership status functionality it also allows the transmission of broadcasts containing a small amount (256 bytes) of arbitrary content to all present healthy members. This maximum is related to the limit imposed on maximum safe UDP packet size by RFC 791 and RFC 2460. We recognize that some systems allow larger packets, however, and although that can risk fragmentation and dropped packets the maximum payload size is configurable.
 
-Smudge was conceived with space-sensitive systems (mobile, IOT, containers) in mind, and therefore was developed with a minimalist philosophy of doing a few things well. As such, its feature set is relatively small and mostly limited to functionality around adding and removing nodes and detecting status changes on the cluster.
+Smudge was conceived with space-sensitive systems (mobile, IoT, containers) in mind, and therefore was developed with a minimalist philosophy of doing a few things well. As such, its feature set is relatively small and mostly limited to functionality around adding and removing nodes and detecting status changes on the cluster.
 
 Complete documentation is available from [the associated Godoc](https://godoc.org/github.com/clockworksoul/smudge).
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ Complete documentation is available from [the associated Godoc](https://godoc.or
 ## Known issues
 * Broadcasts are limited to 256 bytes, or 512 bytes when using IPv6.
 * No WAN support: only local-network, private IPs are supported.
-* No multicast discovery.
 
 ### Deviations from [Motivala, et al](https://pdfs.semanticscholar.org/8712/3307869ac84fc16122043a4a313604bd948f.pdf)
 

--- a/README.md
+++ b/README.md
@@ -144,13 +144,16 @@ Perhaps the simplest way of directing the behavior of the SWIM driver is by sett
 The following variables and their default values are as follows:
 
 ```
-Variable                   | Default   | Description
--------------------------- | --------- | -------------------------------
-SMUDGE_HEARTBEAT_MILLIS    |     250   | Milliseconds between heartbeats
-SMUDGE_INITIAL_HOSTS       |           | Comma-delimmited list of known members as IP or IP:PORT.
-SMUDGE_LISTEN_PORT         |    9999   | UDP port to listen on
-SMUDGE_LISTEN_IP           | 127.0.0.1 | IP address to listen on
-SMUDGE_MAX_BROADCAST_BYTES |     256   | Maximum byte length of broadcast payloads
+Variable                   | Default         | Description
+-------------------------- | --------------- | -------------------------------
+SMUDGE_CLUSTER_NAME        |      smudge     | Cluster name for for multicast discovery
+SMUDGE_HEARTBEAT_MILLIS    |       250       | Milliseconds between heartbeats
+SMUDGE_INITIAL_HOSTS       |                 | Comma-delimmited list of known members as IP or IP:PORT
+SMUDGE_LISTEN_PORT         |       9999      | UDP port to listen on
+SMUDGE_LISTEN_IP           |    127.0.0.1    | IP address to listen on
+SMUDGE_MAX_BROADCAST_BYTES |       256       | Maximum byte length of broadcast payloads
+SMUDGE_MULTICAST_ENABLED   |       true      | Multicast announce on startup; listen for multicast announcements
+SMUDGE_MULTICAST_ADDRESS   | See description | The multicast broadcast address. Default: `224.0.0.0` (IPv4) or `[ff02::1]` (IPv6)
 ```
 
 

--- a/membership.go
+++ b/membership.go
@@ -31,6 +31,10 @@ const lambda = 2.5
 // allow before timing out an ACK.
 const timeoutToleranceSigmas = 3.0
 
+const defaultIPv4MulticastAddress = "224.0.0.0"
+
+const defaultIPv6MulticastAddress = "[ff02::1]"
+
 var currentHeartbeat uint32
 
 var pendingAcks = struct {
@@ -76,12 +80,12 @@ func Begin() {
 
 	logInfo("My host address:", thisHostAddress)
 
-	go listenUDP(GetListenPort())
-
 	// Add this node's status. Don't update any other node's statuses: they'll
 	// report those back to us.
 	updateNodeStatus(thisHost, StatusAlive, 0, thisHost)
 	AddNode(thisHost)
+
+	go listenUDP(GetListenPort())
 
 	// Add initial hosts as specified by the SMUDGE_INITIAL_HOSTS property
 	for _, address := range GetInitialHosts() {
@@ -91,6 +95,11 @@ func Begin() {
 		} else {
 			AddNode(n)
 		}
+	}
+
+	if multicastEnabled {
+		go listenUDPMulticast(GetListenPort() - 1)
+		go multicastAnnounce(getMulticastAddress())
 	}
 
 	go startTimeoutCheckLoop()
@@ -179,15 +188,6 @@ func PingNode(node *Node) error {
  * Private functions (for internal use only)
  *****************************************************************************/
 
-// The number of times any node's new status should be emitted after changes.
-// Currently set to (lambda * log(node count)).
-func emitCount() int {
-	logn := math.Log(float64(knownNodes.length()))
-	mult := (lambda * logn) + 0.5
-
-	return int(mult)
-}
-
 func doForwardOnTimeout(pack *pendingAck) {
 	filteredNodes := getTargetNodes(pingRequestCount(), thisHost, pack.node)
 
@@ -206,6 +206,31 @@ func doForwardOnTimeout(pack *pendingAck) {
 			transmitVerbForwardUDP(n, pack.node, currentHeartbeat)
 		}
 	}
+}
+
+// The number of times any node's new status should be emitted after changes.
+// Currently set to (lambda * log(node count)).
+func emitCount() int {
+	logn := math.Log(float64(knownNodes.length()))
+	mult := (lambda * logn) + 0.5
+
+	return int(mult)
+}
+
+func getMulticastAddress() string {
+	if ipLen == net.IPv4len {
+		if multicastAddress == "" {
+			if ipLen == net.IPv6len {
+				multicastAddress = defaultIPv6MulticastAddress
+			} else if ipLen == net.IPv4len {
+				multicastAddress = defaultIPv4MulticastAddress
+			} else {
+				logFatal("Failed to determine IPv4/IPv6")
+			}
+		}
+	}
+
+	return multicastAddress
 }
 
 // Returns a random slice of valid ping/forward request targets; i.e., not
@@ -256,6 +281,67 @@ func listenUDP(port int) error {
 			}
 		}(addr, buf[0:n])
 	}
+}
+
+func listenUDPMulticast(port int) error {
+	listenAddress, err := net.ResolveUDPAddr("udp", getMulticastAddress()+":"+strconv.FormatInt(int64(port), 10))
+	if err != nil {
+		return err
+	}
+
+	/* Now listen at selected port */
+	c, err := net.ListenMulticastUDP("udp", nil, listenAddress)
+	if err != nil {
+		return err
+	}
+	defer c.Close()
+
+	for {
+		buf := make([]byte, 2048) // big enough to fit 1280 IPv6 UDP message
+		n, addr, err := c.ReadFromUDP(buf)
+		if err != nil {
+			logError("UDP read error:", err)
+		}
+
+		go func(addr *net.UDPAddr, msg []byte) {
+			err = receiveMessageUDP(addr, buf[0:n])
+			if err != nil {
+				logError(err)
+			}
+		}(addr, buf[0:n])
+	}
+}
+
+// multicastAnnounce is called when the server first starts to broadcast its
+// presence to all listening servers within the specified subnet.
+func multicastAnnounce(addr string) error {
+	fullAddr := addr + ":" + strconv.FormatInt(int64(listenPort-1), 10)
+
+	logInfo("Announcing presence on", fullAddr)
+
+	address, err := net.ResolveUDPAddr("udp", fullAddr)
+	if err != nil {
+		logError(err)
+		return err
+	}
+
+	msg := newMessage(verbPing, thisHost, currentHeartbeat)
+
+	c, err := net.DialUDP("udp", nil, address)
+	if err != nil {
+		logError(err)
+		return err
+	}
+
+	_, err = c.Write(msg.encode())
+	if err != nil {
+		logError(err)
+		return err
+	}
+
+	logfTrace("Sent announcement multicast to %v\n", verbPing, getMulticastAddress())
+
+	return nil
 }
 
 // The number of nodes to send a PINGREQ to when a PING times out.

--- a/membership.go
+++ b/membership.go
@@ -218,15 +218,13 @@ func emitCount() int {
 }
 
 func getMulticastAddress() string {
-	if ipLen == net.IPv4len {
-		if multicastAddress == "" {
-			if ipLen == net.IPv6len {
-				multicastAddress = defaultIPv6MulticastAddress
-			} else if ipLen == net.IPv4len {
-				multicastAddress = defaultIPv4MulticastAddress
-			} else {
-				logFatal("Failed to determine IPv4/IPv6")
-			}
+	if multicastAddress == "" {
+		if ipLen == net.IPv6len {
+			multicastAddress = defaultIPv6MulticastAddress
+		} else if ipLen == net.IPv4len {
+			multicastAddress = defaultIPv4MulticastAddress
+		} else {
+			logFatal("Failed to determine IPv4/IPv6")
 		}
 	}
 

--- a/membership.go
+++ b/membership.go
@@ -352,8 +352,6 @@ func listenUDPMulticast(port int) error {
 			name, msgBytes := decodeMulticastAnnounceBytes(bytes)
 
 			if GetClusterName() == name {
-				logfInfo("Got in-cluster multicast announcement: %v\n", name)
-
 				err = receiveMessageUDP(addr, msgBytes)
 				if err != nil {
 					logError(err)

--- a/membership.go
+++ b/membership.go
@@ -329,7 +329,12 @@ func listenUDP(port int) error {
 }
 
 func listenUDPMulticast(port int) error {
-	listenAddress, err := net.ResolveUDPAddr("udp", guessMulticastAddress()+":"+strconv.FormatInt(int64(port), 10))
+	addr := GetMulticastAddress()
+	if addr == "" {
+		addr = guessMulticastAddress()
+	}
+
+	listenAddress, err := net.ResolveUDPAddr("udp", addr+":"+strconv.FormatInt(int64(port), 10))
 	if err != nil {
 		return err
 	}

--- a/properties.go
+++ b/properties.go
@@ -30,6 +30,16 @@ import (
 // default values if not set.
 
 const (
+	// EnvVarClusterName is the name of the environment variable the defines
+	// the name of the cluster. Multicast messages from differently-named
+	// instances are ignored.
+	EnvVarClusterName = "SMUDGE_CLUSTER_NAME"
+
+	// DefaultClusterName is the default name of the cluster for the purposes
+	// of multicast announcements: multicast messages from differently-named
+	// instances are ignored.
+	DefaultClusterName string = "smudge"
+
 	// EnvVarHeartbeatMillis is the name of the environment variable that
 	// sets the heartbeat frequency (in millis).
 	EnvVarHeartbeatMillis = "SMUDGE_HEARTBEAT_MILLIS"
@@ -89,6 +99,8 @@ const (
 	DefaultMulticastAddress string = ""
 )
 
+var clusterName string
+
 var heartbeatMillis int
 
 var listenPort int
@@ -106,6 +118,17 @@ var multicastEnabled bool = true
 var multicastAddress string
 
 const stringListDelimitRegex = "\\s*((,\\s*)|(\\s+))"
+
+// GetHeartbeatMillis gets the name of the cluster for the purposes of
+// multicast announcements: multicast messages from differently-named
+// instances are ignored.
+func GetClusterName() string {
+	if clusterName == "" {
+		clusterName = getStringVar(EnvVarClusterName, DefaultClusterName)
+	}
+
+	return clusterName
+}
 
 // GetHeartbeatMillis gets this host's heartbeat frequency in milliseconds.
 func GetHeartbeatMillis() int {
@@ -172,17 +195,26 @@ func GetMulticastAddress() string {
 	return multicastAddress
 }
 
+// SetClusterName sets the name of the cluster for the purposes of multicast
+// announcements: multicast messages from differently-named instances are
+// ignored.
+func SetClusterName(val string) {
+	if val == "" {
+		clusterName = DefaultClusterName
+	} else {
+		clusterName = val
+	}
+}
+
 // SetHeartbeatMillis sets this nodes heartbeat frequency. Unlike
 // SetListenPort(), calling this function after Begin() has been called will
 // have an effect.
 func SetHeartbeatMillis(val int) {
 	if val == 0 {
-		heartbeatMillis = DefaultListenPort
+		heartbeatMillis = DefaultHeartbeatMillis
 	} else {
 		heartbeatMillis = val
 	}
-
-	heartbeatMillis = val
 }
 
 // SetListenPort sets the UDP port to listen on. It has no effect once

--- a/properties.go
+++ b/properties.go
@@ -81,6 +81,14 @@ const (
 	// message overhead.
 	DefaultMaxBroadcastBytes int = 256
 
+	// EnvVarMulticastAddress is the name of the environment variable that
+	// defines the multicast address that will be used.
+	EnvVarMulticastAddress = "SMUDGE_MULTICAST_ADDRESS"
+
+	// DefaultMulticastAddress is the default multicast address. Empty string
+	// indicates 224.0.0.0 for IPv4 and [ff02::1] for IPv6.
+	DefaultMulticastAddress string = ""
+
 	// EnvVarMulticastEnabled is the name of the environment variable that
 	// describes whether Smudge will attempt to announce its presence via
 	// multicast on startup.
@@ -90,13 +98,13 @@ const (
 	// attempt to announce its presence via multicast on startup.
 	DefaultMulticastEnabled string = "true"
 
-	// EnvVarMulticastAddress is the name of the environment variable that
-	// defines the multicast address that will be used.
-	EnvVarMulticastAddress = "SMUDGE_MULTICAST_ADDRESS"
+	// EnvVarMulticastPort is the name of the environment variable that
+	// defines the multicast announcement listening port.
+	EnvVarMulticastPort = "SMUDGE_MULTICAST_PORT"
 
-	// DefaultMulticastAddress is the default multicast address. Empty string
-	// indicates 224.0.0.0 for IPv4 and [ff02::1] for IPv6.
-	DefaultMulticastAddress string = ""
+	// DefaultMulticastPort is the default value for the multicast
+	// listening port.
+	DefaultMulticastPort int = 9998
 )
 
 var clusterName string
@@ -114,6 +122,8 @@ var maxBroadcastBytes int
 var multicastEnabledString string
 
 var multicastEnabled bool = true
+
+var multicastPort int
 
 var multicastAddress string
 
@@ -195,6 +205,15 @@ func GetMulticastAddress() string {
 	return multicastAddress
 }
 
+// GetMulticastPort returns the defined multicast announcement listening port.
+func GetMulticastPort() int {
+	if multicastPort == 0 {
+		multicastPort = getIntVar(EnvVarMulticastPort, DefaultMulticastPort)
+	}
+
+	return multicastPort
+}
+
 // SetClusterName sets the name of the cluster for the purposes of multicast
 // announcements: multicast messages from differently-named instances are
 // ignored.
@@ -252,11 +271,6 @@ func SetMaxBroadcastBytes(val int) {
 	}
 }
 
-// GetMulticastEnabled sets whether multicast announcements are enabled.
-func SetMulticastEnabled(val bool) {
-	multicastEnabledString = fmt.Sprintf("%v", val)
-}
-
 // SetMulticastAddress sets the address that will be used for multicast
 // announcements.
 func SetMulticastAddress(val string) {
@@ -264,6 +278,20 @@ func SetMulticastAddress(val string) {
 		multicastAddress = DefaultMulticastAddress
 	} else {
 		multicastAddress = val
+	}
+}
+
+// GetMulticastEnabled sets whether multicast announcements are enabled.
+func SetMulticastEnabled(val bool) {
+	multicastEnabledString = fmt.Sprintf("%v", val)
+}
+
+// SetMulticastPort sets multicast announcement listening port.
+func SetMulticastPort(val int) {
+	if val == 0 {
+		multicastPort = DefaultMulticastPort
+	} else {
+		multicastPort = val
 	}
 }
 

--- a/properties.go
+++ b/properties.go
@@ -101,7 +101,7 @@ var maxBroadcastBytes int
 
 var multicastEnabledString string
 
-var multicastEnabled bool
+var multicastEnabled bool = true
 
 var multicastAddress string
 
@@ -156,7 +156,7 @@ func GetMaxBroadcastBytes() int {
 func GetMulticastEnabled() bool {
 	if multicastEnabledString == "" {
 		multicastEnabledString = strings.ToLower(getStringVar(EnvVarMulticastEnabled, DefaultMulticastEnabled))
-		multicastEnabled = len(multicastEnabledString) > 0 && multicastEnabledString[0] == "t"
+		multicastEnabled = len(multicastEnabledString) > 0 && []rune(multicastEnabledString)[0] == 't'
 	}
 
 	return multicastEnabled
@@ -164,7 +164,7 @@ func GetMulticastEnabled() bool {
 
 // GetMulticastAddress returns the address the will be used for multicast
 // announcements.
-func GetMulticastAddress() bool {
+func GetMulticastAddress() string {
 	if multicastAddress == "" {
 		multicastAddress = getStringVar(EnvVarMulticastAddress, DefaultMulticastAddress)
 	}

--- a/properties.go
+++ b/properties.go
@@ -17,6 +17,7 @@ limitations under the License.
 package smudge
 
 import (
+	"fmt"
 	"net"
 	"os"
 	"regexp"
@@ -69,6 +70,23 @@ const (
 	// of 508 bytes, which must also contain status updates and additional
 	// message overhead.
 	DefaultMaxBroadcastBytes int = 256
+
+	// EnvVarMulticastEnabled is the name of the environment variable that
+	// describes whether Smudge will attempt to announce its presence via
+	// multicast on startup.
+	EnvVarMulticastEnabled = "SMUDGE_MULTICAST_ENABLED"
+
+	// DefaultMulticastEnabled is the default value for whether Smudge will
+	// attempt to announce its presence via multicast on startup.
+	DefaultMulticastEnabled string = "true"
+
+	// EnvVarMulticastAddress is the name of the environment variable that
+	// defines the multicast address that will be used.
+	EnvVarMulticastAddress = "SMUDGE_MULTICAST_ADDRESS"
+
+	// DefaultMulticastAddress is the default multicast address. Empty string
+	// indicates 224.0.0.0 for IPv4 and [ff02::1] for IPv6.
+	DefaultMulticastAddress string = ""
 )
 
 var heartbeatMillis int
@@ -80,6 +98,12 @@ var listenIP net.IP
 var initialHosts []string
 
 var maxBroadcastBytes int
+
+var multicastEnabledString string
+
+var multicastEnabled bool
+
+var multicastAddress string
 
 const stringListDelimitRegex = "\\s*((,\\s*)|(\\s+))"
 
@@ -128,6 +152,26 @@ func GetMaxBroadcastBytes() int {
 	return maxBroadcastBytes
 }
 
+// GetMulticastEnabled returns whether multicast announcements are enabled.
+func GetMulticastEnabled() bool {
+	if multicastEnabledString == "" {
+		multicastEnabledString = strings.ToLower(getStringVar(EnvVarMulticastEnabled, DefaultMulticastEnabled))
+		multicastEnabled = len(multicastEnabledString) > 0 && multicastEnabledString[0] == "t"
+	}
+
+	return multicastEnabled
+}
+
+// GetMulticastAddress returns the address the will be used for multicast
+// announcements.
+func GetMulticastAddress() bool {
+	if multicastAddress == "" {
+		multicastAddress = getStringVar(EnvVarMulticastAddress, DefaultMulticastAddress)
+	}
+
+	return multicastAddress
+}
+
 // SetHeartbeatMillis sets this nodes heartbeat frequency. Unlike
 // SetListenPort(), calling this function after Begin() has been called will
 // have an effect.
@@ -173,6 +217,21 @@ func SetMaxBroadcastBytes(val int) {
 		maxBroadcastBytes = DefaultMaxBroadcastBytes
 	} else {
 		maxBroadcastBytes = val
+	}
+}
+
+// GetMulticastEnabled sets whether multicast announcements are enabled.
+func SetMulticastEnabled(val bool) {
+	multicastEnabledString = fmt.Sprintf("%v", val)
+}
+
+// SetMulticastAddress sets the address that will be used for multicast
+// announcements.
+func SetMulticastAddress(val string) {
+	if val == "" {
+		multicastAddress = DefaultMulticastAddress
+	} else {
+		multicastAddress = val
 	}
 }
 


### PR DESCRIPTION
Implements multicast support in response to Issue https://github.com/clockworksoul/smudge/issues/6.

Changes: 

1. The `Begin()` function includes a multicast announcement to all listeners at the specified (configurable) IP and port. Multicast functionality can be disabled; it is enabled by default.
2. Listening instances that receive a multicast announcement will automatically add the sender to its known instances list.
3. Clusters may be assigned a name. Multicast announcements from differently-named clusters are ignored.
4. Added support for the following environmental variables: `SMUDGE_CLUSTER_NAME`, `SMUDGE_MULTICAST_ENABLED`, `SMUDGE_MULTICAST_ADDRESS`, `SMUDGE_MULTICAST_PORT`.
5. README update to reflect above changes.