### PR TITLE
Introduces multicast announce interval

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ SMUDGE_LISTEN_PORT                 |       9999      | UDP port to listen on
 SMUDGE_LISTEN_IP                   |    127.0.0.1    | IP address to listen on
 SMUDGE_MAX_BROADCAST_BYTES         |       256       | Maximum byte length of broadcast payloads
 SMUDGE_MULTICAST_ENABLED           |       true      | Multicast announce on startup; listen for multicast announcements
-SMUDGE_MULTICAST_ANNOUNCE_INTERVAL |        10       | Seconds between multicast announcements, 0 will disable subsequent anouncements
+SMUDGE_MULTICAST_ANNOUNCE_INTERVAL |        0        | Seconds between multicast announcements, 0 will disable subsequent anouncements
 SMUDGE_MULTICAST_ADDRESS           | See description | The multicast broadcast address. Default: `224.0.0.0` (IPv4) or `[ff02::1]` (IPv6)
 SMUDGE_MULTICAST_PORT              |       9998      | The multicast listen port
 ```

--- a/README.md
+++ b/README.md
@@ -144,17 +144,18 @@ Perhaps the simplest way of directing the behavior of the SWIM driver is by sett
 The following variables and their default values are as follows:
 
 ```
-Variable                   | Default         | Description
--------------------------- | --------------- | -------------------------------
-SMUDGE_CLUSTER_NAME        |      smudge     | Cluster name for for multicast discovery
-SMUDGE_HEARTBEAT_MILLIS    |       250       | Milliseconds between heartbeats
-SMUDGE_INITIAL_HOSTS       |                 | Comma-delimmited list of known members as IP or IP:PORT
-SMUDGE_LISTEN_PORT         |       9999      | UDP port to listen on
-SMUDGE_LISTEN_IP           |    127.0.0.1    | IP address to listen on
-SMUDGE_MAX_BROADCAST_BYTES |       256       | Maximum byte length of broadcast payloads
-SMUDGE_MULTICAST_ENABLED   |       true      | Multicast announce on startup; listen for multicast announcements
-SMUDGE_MULTICAST_ADDRESS   | See description | The multicast broadcast address. Default: `224.0.0.0` (IPv4) or `[ff02::1]` (IPv6)
-SMUDGE_MULTICAST_PORT      |       9998      | The multicast listen port
+Variable                           | Default         | Description
+---------------------------------- | --------------- | -------------------------------
+SMUDGE_CLUSTER_NAME                |      smudge     | Cluster name for for multicast discovery
+SMUDGE_HEARTBEAT_MILLIS            |       250       | Milliseconds between heartbeats
+SMUDGE_INITIAL_HOSTS               |                 | Comma-delimmited list of known members as IP or IP:PORT
+SMUDGE_LISTEN_PORT                 |       9999      | UDP port to listen on
+SMUDGE_LISTEN_IP                   |    127.0.0.1    | IP address to listen on
+SMUDGE_MAX_BROADCAST_BYTES         |       256       | Maximum byte length of broadcast payloads
+SMUDGE_MULTICAST_ENABLED           |       true      | Multicast announce on startup; listen for multicast announcements
+SMUDGE_MULTICAST_ANNOUNCE_INTERVAL |        10       | Seconds between multicast announcements, 0 will disable subsequent anouncements
+SMUDGE_MULTICAST_ADDRESS           | See description | The multicast broadcast address. Default: `224.0.0.0` (IPv4) or `[ff02::1]` (IPv6)
+SMUDGE_MULTICAST_PORT              |       9998      | The multicast listen port
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <img src="https://github.com/clockworksoul/smudge/raw/master/logo/logo.png" width="150">
 
-## Introduction 
+## Introduction
 Smudge is a minimalist Go implementation of the [SWIM](https://pdfs.semanticscholar.org/8712/3307869ac84fc16122043a4a313604bd948f.pdf) (Scalable Weakly-consistent Infection-style Membership) protocol for cluster node membership, status dissemination, and failure detection developed at Cornell University by Motivala, et al. It isn't a distributed data store in its own right, but rather a framework intended to facilitate the construction of such systems.
 
 Smudge also extends the standard SWIM protocol so that in addition to the standard membership status functionality it also allows the transmission of broadcasts containing a small amount (256 bytes) of arbitrary content to all present healthy members. This maximum is related to the limit imposed on maximum safe UDP packet size by RFC 791 and RFC 2460. We recognize that some systems allow larger packets, however, and although that can risk fragmentation and dropped packets the maximum payload size is configurable.
@@ -175,35 +175,35 @@ Creating a status change listener is very straight-forward:
 
 ```go
 type MyStatusListener struct {
-	smudge.StatusListener
+    smudge.StatusListener
 }
 
 func (m MyStatusListener) OnChange(node *smudge.Node, status smudge.NodeStatus) {
-	fmt.Printf("Node %s is now status %s\n", node.Address(), status)
+    fmt.Printf("Node %s is now status %s\n", node.Address(), status)
 }
 
 func main() {
-	smudge.AddStatusListener(MyStatusListener{})
+    smudge.AddStatusListener(MyStatusListener{})
 }
 ```
 
 
 ### Creating and adding a broadcast listener
-Adding a broadcast listener is very similar to creating a status listener: 
+Adding a broadcast listener is very similar to creating a status listener:
 
 ```go
 type MyBroadcastListener struct {
-	smudge.BroadcastListener
+    smudge.BroadcastListener
 }
 
 func (m MyBroadcastListener) OnBroadcast(b *smudge.Broadcast) {
-	fmt.Printf("Received broadcast from %v: %s\n",
-		b.Origin().Address(),
-		string(b.Bytes()))
+    fmt.Printf("Received broadcast from %v: %s\n",
+        b.Origin().Address(),
+        string(b.Bytes()))
 }
 
 func main() {
-	smudge.AddBroadcastListener(MyBroadcastListener{})
+    smudge.AddBroadcastListener(MyBroadcastListener{})
 }
 ```
 
@@ -248,46 +248,46 @@ import "fmt"
 import "net"
 
 type MyStatusListener struct {
-	smudge.StatusListener
+    smudge.StatusListener
 }
 
 func (m MyStatusListener) OnChange(node *smudge.Node, status smudge.NodeStatus) {
-	fmt.Printf("Node %s is now status %s\n", node.Address(), status)
+    fmt.Printf("Node %s is now status %s\n", node.Address(), status)
 }
 
 type MyBroadcastListener struct {
-	smudge.BroadcastListener
+    smudge.BroadcastListener
 }
 
 func (m MyBroadcastListener) OnBroadcast(b *smudge.Broadcast) {
-	fmt.Printf("Received broadcast from %s: %s\n",
-		b.Origin().Address(),
-		string(b.Bytes()))
+    fmt.Printf("Received broadcast from %s: %s\n",
+        b.Origin().Address(),
+        string(b.Bytes()))
 }
 
 func main() {
-	heartbeatMillis := 500
-	listenPort := 9999
+    heartbeatMillis := 500
+    listenPort := 9999
 
-	// Set configuration options
-	smudge.SetListenPort(listenPort)
-	smudge.SetHeartbeatMillis(heartbeatMillis)
-	smudge.SetListenIP(net.ParseIP("127.0.0.1"))
+    // Set configuration options
+    smudge.SetListenPort(listenPort)
+    smudge.SetHeartbeatMillis(heartbeatMillis)
+    smudge.SetListenIP(net.ParseIP("127.0.0.1"))
 
-	// Add the status listener
-	smudge.AddStatusListener(MyStatusListener{})
+    // Add the status listener
+    smudge.AddStatusListener(MyStatusListener{})
 
-	// Add the broadcast listener
-	smudge.AddBroadcastListener(MyBroadcastListener{})
+    // Add the broadcast listener
+    smudge.AddBroadcastListener(MyBroadcastListener{})
 
-	// Add a new remote node. Currently, to join an existing cluster you must
-	// add at least one of its healthy member nodes.
-	node, err := smudge.CreateNodeByAddress("localhost:10000")
-	if err == nil {
-		smudge.AddNode(node)
-	}
+    // Add a new remote node. Currently, to join an existing cluster you must
+    // add at least one of its healthy member nodes.
+    node, err := smudge.CreateNodeByAddress("localhost:10000")
+    if err == nil {
+        smudge.AddNode(node)
+    }
 
-	// Start the server!
-	smudge.Begin()
+    // Start the server!
+    smudge.Begin()
 }
 ```

--- a/membership.go
+++ b/membership.go
@@ -367,7 +367,9 @@ func listenUDPMulticast(port int) error {
 }
 
 // multicastAnnounce is called when the server first starts to broadcast its
-// presence to all listening servers within the specified subnet.
+// presence to all listening servers within the specified subnet and continues
+// to broadcast its presence every multicastAnnounceIntervalSeconds in case
+// this value is larger than zero.
 func multicastAnnounce(addr string) error {
 	if addr == "" {
 		addr = guessMulticastAddress()
@@ -400,7 +402,7 @@ func multicastAnnounce(addr string) error {
 
 		logfTrace("Sent announcement multicast to %v\n", fullAddr)
 
-		if GetMulticastAnnounceInterval() > 0 {
+		if GetMulticastAnnounceIntervalSeconds() > 0 {
 			time.Sleep(time.Second * 10)
 		} else {
 			return nil

--- a/membership.go
+++ b/membership.go
@@ -411,7 +411,7 @@ func multicastAnnounce(addr string) error {
 		logfTrace("Sent announcement multicast to %v\n", fullAddr)
 
 		if GetMulticastAnnounceIntervalSeconds() > 0 {
-			time.Sleep(time.Second * 10)
+			time.Sleep(time.Second * time.Duration(GetMulticastAnnounceIntervalSeconds()))
 		} else {
 			return nil
 		}

--- a/membership.go
+++ b/membership.go
@@ -357,8 +357,16 @@ func listenUDPMulticast(port int) error {
 			name, msgBytes := decodeMulticastAnnounceBytes(bytes)
 
 			if GetClusterName() == name {
-				err = receiveMessageUDP(addr, msgBytes)
-				if err != nil {
+				msg, err := decodeMessage(addr.IP, msgBytes)
+				if err == nil {
+					logfTrace("Got multicast %v from %v code=%d\n",
+						msg.verb,
+						msg.sender.Address(),
+						msg.senderHeartbeat)
+
+					// Update statuses of the sender.
+					updateStatusesFromMessage(msg)
+				} else {
 					logError(err)
 				}
 			}

--- a/membership.go
+++ b/membership.go
@@ -383,23 +383,29 @@ func multicastAnnounce(addr string) error {
 		return err
 	}
 
-	c, err := net.DialUDP("udp", nil, address)
-	if err != nil {
-		logError(err)
-		return err
+	for {
+		c, err := net.DialUDP("udp", nil, address)
+		if err != nil {
+			logError(err)
+			return err
+		}
+
+		// Compose and send the multicast announcement
+		msgBytes := encodeMulticastAnnounceBytes()
+		_, err = c.Write(msgBytes)
+		if err != nil {
+			logError(err)
+			return err
+		}
+
+		logfTrace("Sent announcement multicast to %v\n", fullAddr)
+
+		if GetMulticastAnnounceInterval() > 0 {
+			time.Sleep(time.Second * 10)
+		} else {
+			return nil
+		}
 	}
-
-	// Compose and send the multicast announcement
-	msgBytes := encodeMulticastAnnounceBytes()
-	_, err = c.Write(msgBytes)
-	if err != nil {
-		logError(err)
-		return err
-	}
-
-	logfTrace("Sent announcement multicast to %v\n", fullAddr)
-
-	return nil
 }
 
 // The number of nodes to send a PINGREQ to when a PING times out.

--- a/properties.go
+++ b/properties.go
@@ -94,6 +94,15 @@ const (
 	// multicast on startup.
 	EnvVarMulticastEnabled = "SMUDGE_MULTICAST_ENABLED"
 
+	// EnvVarMulticastAnnounceInterval is the name of the environment variable
+	// that describes whether Smudge will attempt to re-announce its presence
+	// via multicast every X seconds.
+	EnvVarMulticastAnnounceInterval = "SMUDGE_MULTICAST_ANNOUNCE_INTERVAL"
+
+	// DefaultMulticastAnnounceInterval is the default value for whether Smudge
+	// will re-announce its presence via multicast
+	DefaultMulticastAnnounceInterval = 10
+
 	// DefaultMulticastEnabled is the default value for whether Smudge will
 	// attempt to announce its presence via multicast on startup.
 	DefaultMulticastEnabled string = "true"
@@ -148,6 +157,8 @@ var multicastEnabledString string
 
 var multicastEnabled bool = true
 
+var multicastAnnounceInterval = 10
+
 var multicastPort int
 
 var multicastAddress string
@@ -156,7 +167,7 @@ var pingHistoryFrontload int
 
 const stringListDelimitRegex = "\\s*((,\\s*)|(\\s+))"
 
-// GetHeartbeatMillis gets the name of the cluster for the purposes of
+// GetClusterName gets the name of the cluster for the purposes of
 // multicast announcements: multicast messages from differently-named
 // instances are ignored.
 func GetClusterName() string {
@@ -230,6 +241,13 @@ func GetMulticastEnabled() bool {
 	}
 
 	return multicastEnabled
+}
+
+// GetMulticastAnnounceInterval returns the amount of seconds to wait between
+// multicast announcements.
+func GetMulticastAnnounceInterval() int {
+	multicastAnnounceInterval = getIntVar(EnvVarMulticastAnnounceInterval, DefaultMulticastAnnounceInterval)
+	return multicastAnnounceInterval
 }
 
 // GetMulticastAddress returns the address the will be used for multicast
@@ -339,9 +357,14 @@ func SetMulticastAddress(val string) {
 	}
 }
 
-// GetMulticastEnabled sets whether multicast announcements are enabled.
+// SetMulticastEnabled sets whether multicast announcements are enabled.
 func SetMulticastEnabled(val bool) {
 	multicastEnabledString = fmt.Sprintf("%v", val)
+}
+
+// SetMulticastAnnounceInterval sets the number of seconds between multicast announcements
+func SetMulticastAnnounceInterval(val int) {
+	multicastAnnounceInterval = val
 }
 
 // SetMulticastPort sets multicast announcement listening port.

--- a/properties.go
+++ b/properties.go
@@ -101,7 +101,7 @@ const (
 
 	// DefaultMulticastAnnounceIntervalSeconds is the default value for whether Smudge
 	// will re-announce its presence via multicast
-	DefaultMulticastAnnounceIntervalSeconds = 10
+	DefaultMulticastAnnounceIntervalSeconds = 0
 
 	// DefaultMulticastEnabled is the default value for whether Smudge will
 	// attempt to announce its presence via multicast on startup.

--- a/properties.go
+++ b/properties.go
@@ -94,18 +94,18 @@ const (
 	// multicast on startup.
 	EnvVarMulticastEnabled = "SMUDGE_MULTICAST_ENABLED"
 
-	// EnvVarMulticastAnnounceInterval is the name of the environment variable
-	// that describes whether Smudge will attempt to re-announce its presence
-	// via multicast every X seconds.
-	EnvVarMulticastAnnounceInterval = "SMUDGE_MULTICAST_ANNOUNCE_INTERVAL"
-
-	// DefaultMulticastAnnounceIntervalSeconds is the default value for whether Smudge
-	// will re-announce its presence via multicast
-	DefaultMulticastAnnounceIntervalSeconds = 0
-
 	// DefaultMulticastEnabled is the default value for whether Smudge will
 	// attempt to announce its presence via multicast on startup.
 	DefaultMulticastEnabled string = "true"
+
+	// EnvVarMulticastAnnounceIntervalSeconds is the name of the environment
+	// variable that describes whether Smudge will attempt to re-announce its
+	// presence via multicast every X seconds.
+	EnvVarMulticastAnnounceIntervalSeconds = "SMUDGE_MULTICAST_ANNOUNCE_INTERVAL"
+
+	// DefaultMulticastAnnounceIntervalSeconds is the default value for whether
+	// Smudge will re-announce its presence via multicast
+	DefaultMulticastAnnounceIntervalSeconds = 0
 
 	// EnvVarMulticastPort is the name of the environment variable that
 	// defines the multicast announcement listening port.
@@ -246,7 +246,7 @@ func GetMulticastEnabled() bool {
 // GetMulticastAnnounceIntervalSeconds returns the amount of seconds to wait between
 // multicast announcements.
 func GetMulticastAnnounceIntervalSeconds() int {
-	multicastAnnounceIntervalSeconds = getIntVar(EnvVarMulticastAnnounceInterval, DefaultMulticastAnnounceIntervalSeconds)
+	multicastAnnounceIntervalSeconds = getIntVar(EnvVarMulticastAnnounceIntervalSeconds, DefaultMulticastAnnounceIntervalSeconds)
 	return multicastAnnounceIntervalSeconds
 }
 

--- a/properties.go
+++ b/properties.go
@@ -99,9 +99,9 @@ const (
 	// via multicast every X seconds.
 	EnvVarMulticastAnnounceInterval = "SMUDGE_MULTICAST_ANNOUNCE_INTERVAL"
 
-	// DefaultMulticastAnnounceInterval is the default value for whether Smudge
+	// DefaultMulticastAnnounceIntervalSeconds is the default value for whether Smudge
 	// will re-announce its presence via multicast
-	DefaultMulticastAnnounceInterval = 10
+	DefaultMulticastAnnounceIntervalSeconds = 10
 
 	// DefaultMulticastEnabled is the default value for whether Smudge will
 	// attempt to announce its presence via multicast on startup.
@@ -155,9 +155,9 @@ var minPingTime int
 
 var multicastEnabledString string
 
-var multicastEnabled bool = true
+var multicastEnabled = true
 
-var multicastAnnounceInterval = 10
+var multicastAnnounceIntervalSeconds = 10
 
 var multicastPort int
 
@@ -243,11 +243,11 @@ func GetMulticastEnabled() bool {
 	return multicastEnabled
 }
 
-// GetMulticastAnnounceInterval returns the amount of seconds to wait between
+// GetMulticastAnnounceIntervalSeconds returns the amount of seconds to wait between
 // multicast announcements.
-func GetMulticastAnnounceInterval() int {
-	multicastAnnounceInterval = getIntVar(EnvVarMulticastAnnounceInterval, DefaultMulticastAnnounceInterval)
-	return multicastAnnounceInterval
+func GetMulticastAnnounceIntervalSeconds() int {
+	multicastAnnounceIntervalSeconds = getIntVar(EnvVarMulticastAnnounceInterval, DefaultMulticastAnnounceIntervalSeconds)
+	return multicastAnnounceIntervalSeconds
 }
 
 // GetMulticastAddress returns the address the will be used for multicast
@@ -362,9 +362,9 @@ func SetMulticastEnabled(val bool) {
 	multicastEnabledString = fmt.Sprintf("%v", val)
 }
 
-// SetMulticastAnnounceInterval sets the number of seconds between multicast announcements
-func SetMulticastAnnounceInterval(val int) {
-	multicastAnnounceInterval = val
+// SetMulticastAnnounceIntervalSeconds sets the number of seconds between multicast announcements
+func SetMulticastAnnounceIntervalSeconds(val int) {
+	multicastAnnounceIntervalSeconds = val
 }
 
 // SetMulticastPort sets multicast announcement listening port.


### PR DESCRIPTION
Multicast announcements repeat every X seconds. X defaults to 10. Repetition can be disabled by setting X to 0.