### PR TITLE
Parses the string value when getting the value for multicastEnabled

### DIFF
--- a/properties.go
+++ b/properties.go
@@ -237,9 +237,9 @@ func GetMinPingTime() int {
 func GetMulticastEnabled() bool {
 	if multicastEnabledString == "" {
 		multicastEnabledString = strings.ToLower(getStringVar(EnvVarMulticastEnabled, DefaultMulticastEnabled))
-		multicastEnabled = len(multicastEnabledString) > 0 && []rune(multicastEnabledString)[0] == 't'
 	}
 
+	multicastEnabled = len(multicastEnabledString) > 0 && []rune(multicastEnabledString)[0] == 't'
 	return multicastEnabled
 }
 


### PR DESCRIPTION
Currently after calling `SetMulticastEnabled(false)` the sting value is changed and because `GetMulticastEnabled()` does not use the string value multicast is never disabled.