### PR TITLE
Allow smudge to listen to the `zero-address`

### DIFF
--- a/membership.go
+++ b/membership.go
@@ -65,12 +65,12 @@ func Begin() {
 	logfInfo("Using listen IP: %s", listenIP)
 
 	// Use IPv6 address length if the listen IP is not an IPv4 address
-	if listenIP.To4() == nil {
+	if GetListenIP().To4() == nil {
 		ipLen = net.IPv6len
 	}
 
 	me := Node{
-		ip:         listenIP,
+		ip:         GetListenIP(),
 		port:       uint16(GetListenPort()),
 		timestamp:  GetNowInMillis(),
 		pingMillis: PingNoData,

--- a/membership.go
+++ b/membership.go
@@ -676,6 +676,11 @@ func transmitVerbGenericUDP(node *Node, forwardTo *Node, verb messageVerb, code 
 		}
 
 		broadcast.emitCounter--
+		// if the nodes listens on all interfaces mark on which interface we sent the broadcast
+		if broadcast.origin.IP().String() == "0.0.0.0" || broadcast.origin.IP().String() == "::" {
+			localAddr := c.LocalAddr().(*net.UDPAddr)
+			updateBroadcast(broadcast, localAddr)
+		}
 	}
 
 	_, err = c.Write(msg.encode())

--- a/message.go
+++ b/message.go
@@ -207,9 +207,13 @@ func (m *message) encode() []byte {
 	}
 
 	if m.broadcast != nil {
-		bbytes := m.broadcast.encode()
-		for i, v := range bbytes {
-			bytes[p+i] = v
+		bbytes, err := m.broadcast.encode()
+		if err != nil {
+			logError(err)
+		} else {
+			for i, v := range bbytes {
+				bytes[p+i] = v
+			}
 		}
 	}
 


### PR DESCRIPTION
This PR is up for discussion.

I wanted to allow Smudge to listen to the zero address (0.0.0.0 or [::]) so that it is not required to configure a specific IP address and (maybe) also allow a node to bridge between different IP ranges.

The problem I faced was that a broadcast message defaults gets the `listenIP` address as the origin address, in case Smudge listens to the `zero-address` this would not be right.

The way I'm trying to solve this is, when the `zero-address` is used, the `origin` address on the broadcast gets updated with the local IP address used to send the broadcast message to another node.

Does this make sense? Is there another approach to solve this?
