### PR TITLE
Fixes issue where the multicast is not send from the listen IP address

### DIFF
--- a/membership.go
+++ b/membership.go
@@ -18,6 +18,7 @@ package smudge
 
 import (
 	"errors"
+	"fmt"
 	"math"
 	"net"
 	"strconv"
@@ -402,14 +403,17 @@ func multicastAnnounce(addr string) error {
 		logError(err)
 		return err
 	}
-
+	laddr, err := net.ResolveUDPAddr("udp", fmt.Sprintf("%s:0", GetListenIP().String()))
+	if err != nil {
+		logError(err)
+		return err
+	}
 	for {
-		c, err := net.DialUDP("udp", nil, address)
+		c, err := net.DialUDP("udp", laddr, address)
 		if err != nil {
 			logError(err)
 			return err
 		}
-
 		// Compose and send the multicast announcement
 		msgBytes := encodeMulticastAnnounceBytes()
 		_, err = c.Write(msgBytes)
@@ -418,7 +422,7 @@ func multicastAnnounce(addr string) error {
 			return err
 		}
 
-		logfTrace("Sent announcement multicast to %v", fullAddr)
+		logfTrace("Sent announcement multicast from %v to %v", laddr, fullAddr)
 
 		if GetMulticastAnnounceIntervalSeconds() > 0 {
 			time.Sleep(time.Second * time.Duration(GetMulticastAnnounceIntervalSeconds()))

--- a/membership.go
+++ b/membership.go
@@ -18,7 +18,6 @@ package smudge
 
 import (
 	"errors"
-	"fmt"
 	"math"
 	"net"
 	"strconv"
@@ -285,6 +284,7 @@ func guessMulticastAddress() string {
 	return multicastAddress
 }
 
+// getListenInterface gets the network interface for the listen IP
 func getListenInterface() (*net.Interface, error) {
 	ifaces, err := net.Interfaces()
 	if err == nil {
@@ -431,17 +431,9 @@ func multicastAnnounce(addr string) error {
 		logError(err)
 		return err
 	}
-	var fullLaddr string
-	if ipLen == net.IPv6len {
-		fullLaddr = fmt.Sprintf("[%s]:0", GetListenIP().String())
-	} else {
-		fullLaddr = fmt.Sprintf("%s:0", GetListenIP().String())
-	}
-	laddr, err := net.ResolveUDPAddr("udp", fullLaddr)
-
-	if err != nil {
-		logError(err)
-		return err
+	laddr := &net.UDPAddr{
+		IP:   GetListenIP(),
+		Port: 0,
 	}
 	for {
 		c, err := net.DialUDP("udp", laddr, address)

--- a/membership.go
+++ b/membership.go
@@ -403,7 +403,13 @@ func multicastAnnounce(addr string) error {
 		logError(err)
 		return err
 	}
-	laddr, err := net.ResolveUDPAddr("udp", fmt.Sprintf("%s:0", GetListenIP().String()))
+	var fullLaddr string
+	if ipLen == net.IPv6len {
+		fullLaddr = fmt.Sprintf("[%s]:0", GetListenIP().String())
+	} else {
+		fullLaddr = fmt.Sprintf("%s:0", GetListenIP().String())
+	}
+	laddr, err := net.ResolveUDPAddr("udp", fullLaddr)
 	if err != nil {
 		logError(err)
 		return err


### PR DESCRIPTION
I noticed that in some situations the multicast announcement is send on the wrong interface. This PR fixes that issue by explicitly sending the announcement from the ListenIP.
