### PR TITLE
Fix parsing integer environment variables

### DIFF
--- a/properties.go
+++ b/properties.go
@@ -398,7 +398,7 @@ func getIntVar(key string, defaultVal int) int {
 	valueInt := defaultVal
 
 	if valueString != "" {
-		i, err := strconv.Atoi(key)
+		i, err := strconv.Atoi(valueString)
 
 		if err != nil {
 			logfWarn("Failed to parse env property %s: %s is not "+


### PR DESCRIPTION
Was converting the key, not the value retrieved so any non-default parameters were ignored